### PR TITLE
extrai dados de leitos da API REST do painel do governo

### DIFF
--- a/data/dados_pb_covid19_leitos.csv
+++ b/data/dados_pb_covid19_leitos.csv
@@ -1,0 +1,2 @@
+data,uti_disponivel,uti_ocupado,uti_total,enfermaria_disponivel,enfermaria_ocupado,enfermaria_total,total_disponivel,total_ocupado,total
+2020-04-30,103,68,171,328,97,425,431,165,596

--- a/scripts/atualiza_dados_leitos_pb.py
+++ b/scripts/atualiza_dados_leitos_pb.py
@@ -1,0 +1,44 @@
+from datetime import date
+import csv
+import requests
+import os.path
+import sys
+
+def main(argv):
+
+    csv_file = 'dados_pb_covid19_leitos.csv' if len(argv) == 0 else argv[0]
+
+    data = date.today().strftime('%Y-%m-%d')
+
+    r_uti = requests.get('https://superset.plataformatarget.com.br/superset/explore_json/?form_data=%7B%22slice_id%22%3A615%7D').json()
+    uti_disponivel = r_uti['data'][0]['y']
+    uti_ocupado = r_uti['data'][1]['y']
+    uti_total = uti_disponivel + uti_ocupado
+
+    r_enfermaria = requests.get('https://superset.plataformatarget.com.br/superset/explore_json/?form_data=%7B%22slice_id%22%3A620%7D').json()
+    enfermaria_disponivel = r_enfermaria['data'][0]['y']
+    enfermaria_ocupado = r_enfermaria['data'][1]['y']
+    enfermaria_total = enfermaria_disponivel + enfermaria_ocupado
+
+    leitos = {
+        "data": data,
+        "uti_disponivel": int(uti_disponivel),
+        "uti_ocupado": int(uti_ocupado),
+        "uti_total": int(uti_total),
+        "enfermaria_disponivel": int(enfermaria_disponivel),
+        "enfermaria_ocupado": int(enfermaria_ocupado),
+        "enfermaria_total": int(enfermaria_total),
+        "total_disponivel": int(uti_disponivel + enfermaria_disponivel),
+        "total_ocupado": int(uti_ocupado + enfermaria_ocupado),
+        "total": int(uti_total + enfermaria_total)
+    }
+
+    file_exists = os.path.isfile(csv_file)
+    with open(csv_file, 'a') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=leitos.keys())
+            if not file_exists:
+                writer.writeheader()
+            writer.writerow(leitos)
+
+if __name__ == "__main__":
+   main(sys.argv[1:])


### PR DESCRIPTION
Para executar do diretório raíz do projeto:
`python scripts/atualiza_dados_leitos_pb.py dados/dados_pb_covid19_leitos.csv`

O parâmetro é o arquivo CSV de saída. Se o arquivo já existir, ele dá um append no fim do arquivo. Se não existir, ele cria um novo com um header.

Algo que pode ser melhorado: se já houver registro para uma data, atualizar sem duplicar os dados para uma mesma data. No futuro também pode criar uma coluna `ultima_atualizacao` que seria atualizada ao rodar o script.